### PR TITLE
DefaultLayoutの不要なHookを削除しました。Headerの表示を任意にしました

### DIFF
--- a/services/frontend/src/components/DefaultLayout.tsx
+++ b/services/frontend/src/components/DefaultLayout.tsx
@@ -1,21 +1,17 @@
 import { Header } from './Header'
 
 import { Box, Flex } from '@chakra-ui/react'
-import { ReactNode, useCallback, useState } from 'react'
+import { ReactNode } from 'react'
 
 type DefaultLayoutProps = {
   children: ReactNode
+  hideHeader?: boolean // ヘッダーを表示するかしないか( trueで隠す )
 }
 
-export const DefaultLayout = ({ children }: DefaultLayoutProps) => {
-  const [isOpen, setIsOpen] = useState(false)
-  const handleClickMenu = useCallback(() => {
-    setIsOpen((prev) => !prev)
-  }, [])
+export const DefaultLayout = ({ children, hideHeader }: DefaultLayoutProps) => {
   return (
     <Flex bg="#EFF0F3" flexDir="column" h="200vh">
-      <Header />
-
+      {!hideHeader ? <Header /> : <></>}
       <Flex flex={1}>
         <Box flex={1} overflowY="scroll">
           {children}

--- a/services/frontend/src/pages/experiment_form.tsx
+++ b/services/frontend/src/pages/experiment_form.tsx
@@ -95,7 +95,7 @@ const Page = () => {
 
   // ここからページ
   return (
-    <DefaultLayout>
+    <DefaultLayout hideHeader={true}>
       {/* 見出し */}
       <Heading p="10">体験入会申請フォーム</Heading>
       {/* メインの部分, フォームはここにする */}

--- a/services/frontend/src/pages/login.tsx
+++ b/services/frontend/src/pages/login.tsx
@@ -1,5 +1,14 @@
 import { DefaultLayout } from '../components/DefaultLayout'
-import { Box, Flex, Text, Input, Button, Link , InputGroup, InputRightElement } from '@chakra-ui/react'
+import {
+  Box,
+  Flex,
+  Text,
+  Input,
+  Button,
+  Link,
+  InputGroup,
+  InputRightElement,
+} from '@chakra-ui/react'
 import React from 'react'
 
 import Logo from '../assets/images/icon.png'
@@ -18,7 +27,7 @@ const Page = () => {
   const isInvalid = !username || !password
 
   return (
-    <DefaultLayout>
+    <DefaultLayout hideHeader={true}>
       <Box pt={5} px={10}>
         <Flex align="center" as="form" direction="column" justify="center">
           <Box


### PR DESCRIPTION
`DefaultLayout`の不要なHookを削除しました。
`DefaultLayout`の`hideHeader`propsを`true`にすることで、Headerを非表示にすることができます。
また、`Login`, `experiment_form`などのHeaderが不要なページは上記のpropsを反映しました。
