### PR TITLE
Authenticatedの適用

### DIFF
--- a/services/frontend/src/components/DefaultLayout.tsx
+++ b/services/frontend/src/components/DefaultLayout.tsx
@@ -2,24 +2,48 @@ import { Header } from './Header'
 
 import { Box, Flex } from '@chakra-ui/react'
 import type { ReactNode } from 'react'
+import { Authenticated } from './Authenticated'
 
 type DefaultLayoutProps = {
   children?: ReactNode
   hideHeader?: boolean // ヘッダーを表示するかしないか( trueで隠す )
+  authenticated?: boolean
 }
 
-export const DefaultLayout = ({ children, hideHeader }: DefaultLayoutProps) => {
-  return (
-    <Flex bg="#EFF0F3" flexDir="column" h="100vh">
-      {!hideHeader ? <Header /> : null}
+export const DefaultLayout = ({
+  children,
+  hideHeader,
+  authenticated = true,
+}: DefaultLayoutProps) => {
+  if (authenticated) {
+    return (
+      <Authenticated>
+        <Flex bg="#EFF0F3" flexDir="column" h="100vh">
+          {!hideHeader ? <Header /> : null}
 
-      <Flex flex={1} overflowY="hidden">
-        <Box flex={1} overflowY="scroll">
-          {children}
+          <Flex flex={1} overflowY="hidden">
+            <Box flex={1} overflowY="scroll">
+              {children}
 
-          {/* <Sidebar display={isOpen?'block':'none'}/> */}
-        </Box>
+              {/* <Sidebar display={isOpen?'block':'none'}/> */}
+            </Box>
+          </Flex>
+        </Flex>
+      </Authenticated>
+    )
+  } else {
+    return (
+      <Flex bg="#EFF0F3" flexDir="column" h="100vh">
+        {!hideHeader ? <Header /> : null}
+
+        <Flex flex={1} overflowY="hidden">
+          <Box flex={1} overflowY="scroll">
+            {children}
+
+            {/* <Sidebar display={isOpen?'block':'none'}/> */}
+          </Box>
+        </Flex>
       </Flex>
-    </Flex>
-  )
+    )
+  }
 }

--- a/services/frontend/src/modules/trialApplication/pages/SubmitTrialApplicationPage.tsx
+++ b/services/frontend/src/modules/trialApplication/pages/SubmitTrialApplicationPage.tsx
@@ -50,7 +50,7 @@ export const SubmitTrialApplicationPage = () => {
   }
 
   return (
-    <DefaultLayout hideHeader>
+    <DefaultLayout authenticated={false} hideHeader>
       <Heading p="10">体験入会申請フォーム</Heading>
 
       <Container fontSize="1em" w="100%">

--- a/services/frontend/src/pages/index.tsx
+++ b/services/frontend/src/pages/index.tsx
@@ -1,13 +1,10 @@
-import { Authenticated } from '../components/Authenticated'
 import { DefaultLayout } from '../components/DefaultLayout'
 
 const Page = () => {
   return (
-    <Authenticated>
-      <DefaultLayout>
-        <p>データサイエンスクラブ</p>
-      </DefaultLayout>
-    </Authenticated>
+    <DefaultLayout>
+      <p>データサイエンスクラブ</p>
+    </DefaultLayout>
   )
 }
 

--- a/services/frontend/src/pages/login.tsx
+++ b/services/frontend/src/pages/login.tsx
@@ -42,7 +42,7 @@ const Page = () => {
   }
 
   return (
-    <DefaultLayout hideHeader>
+    <DefaultLayout authenticated={false} hideHeader>
       <Container mt="5%" w="100%">
         <VStack align="center">
           <Image

--- a/services/frontend/src/pages/viewTerms.tsx
+++ b/services/frontend/src/pages/viewTerms.tsx
@@ -1,10 +1,10 @@
-import { Heading, Box } from '@chakra-ui/react'
+import { Box, Heading } from '@chakra-ui/react'
 import { DefaultLayout } from '../components/DefaultLayout'
 // import { useState } from 'react'
 
 const Page = () => {
   return (
-    <DefaultLayout>
+    <DefaultLayout authenticated={false}>
       {/* <Text>あいうえお</Text> */}
 
       <Box justifyContent="center" p={5}>


### PR DESCRIPTION
# 概要
ログインしている人だけが見れるページに`<Authenticated>`を適用しました。
#62 

ログインページ
体験入会申請フォームページ
体験入会申請確認ページ
会員規約ページ

には適用していません。

# 変更内容
`DefaultLayoutProps`に`authenticated`を追加しました。
```javascript
type DefaultLayoutProps = {
  children?: ReactNode
  hideHeader?: boolean // ヘッダーを表示するかしないか( trueで隠す )
  authenticated?: boolean
}
```

デフォルトで<Authenticated>を適用するようにしていますので、適用したくないページにのみ以下のように、propsを渡してください。

```javascript
<DefaultLayout authenticated={false}>
```

# DefaultLayoutにpropsとして渡す仕様にした理由
各ページに直接記述適用してしまうと
`Expected the depth of nested jsx elements to be <= 5`
を満たすことが厳しくなる場面がでると思ったからです。