### PR TITLE
体験入会管理ページのフロント作成

### DIFF
--- a/services/frontend/src/modules/trailManagement/components/ConfirmDialog/CancelDialog.tsx
+++ b/services/frontend/src/modules/trailManagement/components/ConfirmDialog/CancelDialog.tsx
@@ -1,0 +1,115 @@
+import {
+  Button,
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+  useToast,
+  TableContainer,
+  Tbody,
+  Td,
+  Th,
+  Tr,
+  TableCaption,
+  Table,
+} from '@chakra-ui/react'
+import { useRef } from 'react'
+
+type UserType = {
+  id: string
+  name: string
+  trialEndDate: string
+  trialStartDate: string
+}
+
+type UserInfoTableProps = {
+  user: UserType | null
+}
+const UserInfoTable = ({ user }: UserInfoTableProps) => {
+  return (
+    <TableContainer>
+      <Table>
+        <Tbody>
+          <Tr>
+            <Th>名前</Th>
+
+            <Td>{user?.name}</Td>
+          </Tr>
+
+          <Tr>
+            <Th>体験入会開始日</Th>
+
+            <Td>{user?.trialStartDate}</Td>
+          </Tr>
+
+          <Tr>
+            <Th>体験入会終了日</Th>
+
+            <Td>{user?.trialEndDate}</Td>
+          </Tr>
+        </Tbody>
+
+        <TableCaption>
+          本当にキャンセルしますか？この操作は取り消せません。
+        </TableCaption>
+      </Table>
+    </TableContainer>
+  )
+}
+
+type CancelDialogProps = {
+  isOpen: boolean
+  onClose: () => void
+  user: UserType | null
+}
+export const CanselDialog = ({ isOpen, onClose, user }: CancelDialogProps) => {
+  const cancelRef = useRef(null)
+  const toast = useToast()
+  const handleClickCanselButton = () => {
+    onClose()
+    toast({
+      duration: 3000,
+      isClosable: true,
+      status: 'success',
+      title: 'キャンセルしました',
+    })
+  }
+
+  return (
+    <>
+      <AlertDialog
+        isOpen={isOpen}
+        leastDestructiveRef={cancelRef}
+        onClose={onClose}
+      >
+        <AlertDialogOverlay>
+          <AlertDialogContent>
+            <AlertDialogHeader fontSize="lg" fontWeight="bold">
+              体験入会キャンセル確認画面
+            </AlertDialogHeader>
+
+            <AlertDialogBody>
+              <UserInfoTable user={user} />
+            </AlertDialogBody>
+
+            <AlertDialogFooter>
+              <Button onClick={onClose} ref={cancelRef}>
+                戻る
+              </Button>
+
+              <Button
+                colorScheme="red"
+                ml={3}
+                onClick={handleClickCanselButton}
+              >
+                キャンセルする
+              </Button>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      </AlertDialog>
+    </>
+  )
+}

--- a/services/frontend/src/modules/trailManagement/components/TrialManagementTable.tsx
+++ b/services/frontend/src/modules/trailManagement/components/TrialManagementTable.tsx
@@ -1,0 +1,63 @@
+import {
+  Button,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react'
+
+const sampleUsers = [
+  {
+    id: '1',
+    name: '山田太郎',
+    trialEndDate: '2021-01-31',
+    trialStartDate: '2021-01-01',
+  },
+  {
+    id: '2',
+    name: '山田花子',
+    trialEndDate: '2021-12-31',
+    trialStartDate: '2021-12-01',
+  },
+]
+const CanselButton = () => {
+  return <Button colorScheme="orange">キャンセル</Button>
+}
+export const TrialManagementTable = () => {
+  return (
+    <TableContainer border="1px solid black" rounded="10">
+      <Table variant="simple">
+        <Thead bg="orange.200">
+          <Tr>
+            <Th>名前</Th>
+
+            <Th>体験入会開始日</Th>
+
+            <Th>体験入会終了日</Th>
+
+            <Th>キャンセル</Th>
+          </Tr>
+        </Thead>
+
+        <Tbody>
+          {sampleUsers.map((user) => (
+            <Tr key={user.id}>
+              <Td>{user.name}</Td>
+
+              <Td>{user.trialStartDate}</Td>
+
+              <Td>{user.trialEndDate}</Td>
+
+              <Td>
+                <CanselButton />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </TableContainer>
+  )
+}

--- a/services/frontend/src/modules/trailManagement/components/TrialManagementTable.tsx
+++ b/services/frontend/src/modules/trailManagement/components/TrialManagementTable.tsx
@@ -7,9 +7,18 @@ import {
   Th,
   Thead,
   Tr,
+  useDisclosure,
 } from '@chakra-ui/react'
+import { useState } from 'react'
+import { CanselDialog } from './ConfirmDialog/CancelDialog'
 
-const sampleUsers = [
+type UserType = {
+  id: string
+  name: string
+  trialEndDate: string
+  trialStartDate: string
+}
+const sampleUsers: UserType[] = [
   {
     id: '1',
     name: '山田太郎',
@@ -23,10 +32,14 @@ const sampleUsers = [
     trialStartDate: '2021-12-01',
   },
 ]
-const CanselButton = () => {
-  return <Button colorScheme="orange">キャンセル</Button>
-}
 export const TrialManagementTable = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [targetUser, setTargetUser] = useState<UserType | null>(null)
+  const handleClickCanselButton = (user: UserType) => {
+    setTargetUser(user)
+    onOpen()
+  }
+
   return (
     <TableContainer border="1px solid black" rounded="10">
       <Table variant="simple">
@@ -52,12 +65,21 @@ export const TrialManagementTable = () => {
               <Td>{user.trialEndDate}</Td>
 
               <Td>
-                <CanselButton />
+                <Button
+                  colorScheme="orange"
+                  onClick={() => {
+                    handleClickCanselButton(user)
+                  }}
+                >
+                  キャンセル
+                </Button>
               </Td>
             </Tr>
           ))}
         </Tbody>
       </Table>
+
+      <CanselDialog isOpen={isOpen} onClose={onClose} user={targetUser} />
     </TableContainer>
   )
 }

--- a/services/frontend/src/modules/trailManagement/pages/TrialManagementPage.graphql
+++ b/services/frontend/src/modules/trailManagement/pages/TrialManagementPage.graphql
@@ -1,0 +1,5 @@
+query TrialManagementPage($userId: ID!) {
+  getUser(id: $userId) {
+    roles
+  }
+}

--- a/services/frontend/src/modules/trailManagement/pages/trialManagementPage.tsx
+++ b/services/frontend/src/modules/trailManagement/pages/trialManagementPage.tsx
@@ -1,0 +1,40 @@
+import { Container, Heading } from '@chakra-ui/react'
+import { useAuthState } from 'react-firebase-hooks/auth'
+import { auth } from '../../../clients/firebase'
+import { Loading } from '../../../components/Loading'
+import {
+  UserRole,
+  useTrialManagementPageQuery,
+} from '../../../generates/graphql'
+import { TrialManagementTable } from '../components/TrialManagementTable'
+
+export const TrialManagementPage = () => {
+  const [user, authLoading] = useAuthState(auth)
+  const { data, loading: queryLoading } = useTrialManagementPageQuery({
+    skip: !user || authLoading,
+    variables: { userId: user?.uid || '' },
+  })
+
+  if (authLoading || queryLoading) {
+    return <Loading />
+  }
+
+  if (!data) {
+    return <Heading>データの取得に失敗しました</Heading>
+  }
+
+  const { roles } = data.getUser
+  if (!roles.includes(UserRole.Admin) && !roles.includes(UserRole.Staff)) {
+    return <Heading>権限がありません</Heading>
+  }
+
+  return (
+    <>
+      <Heading p="5">体験入会管理ページ</Heading>
+
+      <Container>
+        <TrialManagementTable />
+      </Container>
+    </>
+  )
+}

--- a/services/frontend/src/pages/trial-management.tsx
+++ b/services/frontend/src/pages/trial-management.tsx
@@ -1,0 +1,12 @@
+import { DefaultLayout } from '../components/DefaultLayout'
+import { TrialManagementPage } from '../modules/trailManagement/pages/trialManagementPage'
+
+const Page = () => {
+  return (
+    <DefaultLayout>
+      <TrialManagementPage />
+    </DefaultLayout>
+  )
+}
+
+export default Page


### PR DESCRIPTION
## 対応するIssue
- #103 

## 要件

- [x] 管理者・運営スタッフのみ閲覧可能
- [x] キャンセルを押すと確認画面を表示できるように