### PR TITLE
教材ページのフロントを作成

### DIFF
--- a/services/frontend/src/modules/materials/components/MaterialNotice.tsx
+++ b/services/frontend/src/modules/materials/components/MaterialNotice.tsx
@@ -1,0 +1,24 @@
+import { Box, Heading, ListItem, OrderedList } from '@chakra-ui/react'
+import { COLORS } from '../../../theme'
+
+export const MaterialNotice = () => {
+  return (
+    <Box bg={COLORS.white} borderRadius="20" overflow="scroll" p="5">
+      <Heading>注意事項</Heading>
+
+      <OrderedList>
+        <ListItem>教材はダウンロードして利用してください。</ListItem>
+
+        <ListItem>
+          Pythonのコードが付属されていることがあります。その際はお手元でPythonが動く環境を整えて下さい。
+        </ListItem>
+
+        <ListItem>教材の共有は禁止です。</ListItem>
+
+        <ListItem>
+          教材の共有が発覚した場合、当該教材へのアクセス権が消滅します。また、複数回共有が発覚した場合は除名処分や金銭等の要求を行うなど厳しい処分を課します。
+        </ListItem>
+      </OrderedList>
+    </Box>
+  )
+}

--- a/services/frontend/src/modules/materials/components/MaterialPreview.tsx
+++ b/services/frontend/src/modules/materials/components/MaterialPreview.tsx
@@ -1,0 +1,14 @@
+import { Box, Center } from '@chakra-ui/react'
+import type { ReactNode } from 'react'
+import { COLORS } from '../../../theme'
+
+type MaterialPreviewProps = {
+  material?: ReactNode | null
+}
+export const MaterialPreview = ({ material }: MaterialPreviewProps) => {
+  return (
+    <Box bg={COLORS.white} borderRadius="20" p="5" w="full">
+      {material ? material : <Center>教材を選択してください</Center>}
+    </Box>
+  )
+}

--- a/services/frontend/src/modules/materials/components/MaterialSelecter.tsx
+++ b/services/frontend/src/modules/materials/components/MaterialSelecter.tsx
@@ -1,0 +1,39 @@
+import { Box, FormLabel, Select } from '@chakra-ui/react'
+import { Control, Controller } from 'react-hook-form'
+
+type MaterialSelecterProps = {
+  control: Control<{ material: string | undefined }>
+  materials: {
+    id: string
+    name: string
+  }[]
+}
+export const MaterialSelecter = ({
+  control,
+  materials,
+}: MaterialSelecterProps) => {
+  return (
+    <Box w="50%">
+      <FormLabel fontWeight="semibold">選択した教材</FormLabel>
+
+      <Controller
+        control={control}
+        name="material"
+        render={({ field: { value, onChange } }) => (
+          <Select
+            bg="gray.300"
+            onChange={onChange}
+            placeholder="教材を選択"
+            value={value}
+          >
+            {materials.map((material) => (
+              <option key={material.id} value={material.id}>
+                {material.name}
+              </option>
+            ))}
+          </Select>
+        )}
+      />
+    </Box>
+  )
+}

--- a/services/frontend/src/modules/materials/page/MaterialsPage.tsx
+++ b/services/frontend/src/modules/materials/page/MaterialsPage.tsx
@@ -1,0 +1,65 @@
+import {
+  Checkbox,
+  Container,
+  Heading,
+  useBoolean,
+  Text,
+  VStack,
+  Button,
+  Box,
+} from '@chakra-ui/react'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { COLORS } from '../../../theme'
+import { MaterialNotice } from '../components/MaterialNotice'
+import { MaterialPreview } from '../components/MaterialPreview'
+import { MaterialSelecter } from '../components/MaterialSelecter'
+
+const materials = [
+  {
+    id: '1',
+    name: 'Material 1',
+  },
+  {
+    id: '2',
+    name: 'Material 2',
+  },
+]
+
+export const MaterialsPage = () => {
+  const [isChecked, setIsChecked] = useBoolean(false)
+  const { control, watch } = useForm<{ material: string | undefined }>()
+  const selectedMaterial = watch('material')
+  useEffect(() => {
+    console.info('selectedMaterial', selectedMaterial)
+  }, [selectedMaterial])
+
+  return (
+    <Box p="5">
+      <Heading>教材ページ</Heading>
+
+      <Text as="h2">教材の閲覧が可能なページになります。</Text>
+
+      <Container as={VStack} gap={5}>
+        <MaterialSelecter control={control} materials={materials} />
+
+        <MaterialPreview material={null} />
+
+        <MaterialNotice />
+
+        <Checkbox isChecked={isChecked} onChange={() => setIsChecked.toggle()}>
+          注意事項を確認しました
+        </Checkbox>
+
+        <Button
+          _hover={{ opacity: 0.8 }}
+          bg={COLORS.orange}
+          color={COLORS.white}
+          isDisabled={!isChecked}
+        >
+          教材をダウンロード
+        </Button>
+      </Container>
+    </Box>
+  )
+}

--- a/services/frontend/src/pages/materials.tsx
+++ b/services/frontend/src/pages/materials.tsx
@@ -1,0 +1,12 @@
+import { DefaultLayout } from '../components/DefaultLayout'
+import { MaterialsPage } from '../modules/materials/page/MaterialsPage'
+
+const Page = () => {
+  return (
+    <DefaultLayout>
+      <MaterialsPage />
+    </DefaultLayout>
+  )
+}
+
+export default Page


### PR DESCRIPTION
# 対応するissue
- #159 

# 概要
<img width="600" alt="image" src="https://user-images.githubusercontent.com/104000239/195977429-83c2e353-241b-40c2-b2b0-b8b2b6ce0706.png">

`/materials`に作成