### PR TITLE
YYYY-MM-DD形式でないとカスタムスカラー`Date`がエラーになるのを修正

### DIFF
--- a/services/backend/src/resolvers/TrialUser.expiredAt.ts
+++ b/services/backend/src/resolvers/TrialUser.expiredAt.ts
@@ -7,7 +7,12 @@ export const TrialUserExpiredAtResolver: TrialUserResolvers['expiredAt'] = (
     new Date(trialUser.createdAt).getMonth() + 1,
   )
 
-  return `${new Date(expiredAt).getFullYear()}-${
+  return `${new Date(expiredAt).getFullYear()}-${(
     new Date(expiredAt).getMonth() + 1
-  }-${new Date(expiredAt).getDate()}`
+  )
+    .toString()
+    .padStart(2, '0')}-${new Date(expiredAt)
+    .getDate()
+    .toString()
+    .padStart(2, '0')}`
 }


### PR DESCRIPTION
参考
![image](https://user-images.githubusercontent.com/104000239/200558510-9c1ddcd1-3c44-4a0c-9d68-e6fe6e87036a.png)

`date-fns`を導入してもいいかもしれない