### PR TITLE
apolloのキャッシュを利用してユーザーの状態を更新できるように修正

### DIFF
--- a/services/backend/schema.graphql
+++ b/services/backend/schema.graphql
@@ -225,5 +225,5 @@ type Mutation {
   createTrialUser(input: createTrialUserInput!): TrialUser!
   enrollTrialUser(userId: ID!): RegularUser!
   deleteTrialUser(userId: ID!): TrialUser!
-  enableTrialUser(userId: ID!): Boolean!
+  enableTrialUser(userId: ID!): TrialUser!
 }

--- a/services/backend/src/resolvers/Mutation.enableTrialUser.ts
+++ b/services/backend/src/resolvers/Mutation.enableTrialUser.ts
@@ -9,7 +9,7 @@ export const enableTrialUserResolver: NonNullable<
   try {
     const trialUser = await getTrialUser(userId)
     if (!trialUser) {
-      return false
+      throw new Error('ユーザーが見つかりません')
     }
 
     if (
@@ -22,8 +22,13 @@ export const enableTrialUserResolver: NonNullable<
     await auth.updateUser(userId, {
       disabled: false,
     })
-    return true
+    const updatedTrialUser = await getTrialUser(userId)
+    if (!updatedTrialUser) {
+      throw new Error('ユーザーが見つかりません')
+    }
+    return updatedTrialUser
   } catch (error) {
-    return false
+    console.error(error)
+    throw new Error('不明なエラーが発生しました')
   }
 }

--- a/services/frontend/src/modules/trailManagement/components/TrialManagementTable.graphql
+++ b/services/frontend/src/modules/trailManagement/components/TrialManagementTable.graphql
@@ -8,5 +8,8 @@ fragment TrialManagementTable on TrialUser {
 }
 
 mutation EnableTrialUser($userId: ID!) {
-  enableTrialUser(userId: $userId)
+  enableTrialUser(userId: $userId) {
+    id
+    disabled
+  }
 }

--- a/services/frontend/src/modules/trailManagement/components/TrialManagementTable.tsx
+++ b/services/frontend/src/modules/trailManagement/components/TrialManagementTable.tsx
@@ -10,10 +10,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { useState } from 'react'
-import { useAuthState } from 'react-firebase-hooks/auth'
-import { auth } from '../../../clients/firebase'
 import {
-  TrialManagementPageDocument,
   TrialManagementTableFragment,
   useEnableTrialUserMutation,
 } from '../../../generates/graphql'
@@ -26,7 +23,6 @@ type TrialManagementTableProps = {
 export const TrialManagementTable = ({
   trialUsers,
 }: TrialManagementTableProps) => {
-  const [user, _loading] = useAuthState(auth)
   const [enableTrialUserMutation, { loading }] = useEnableTrialUserMutation({})
   const {
     isOpen: isOpenCancel,
@@ -45,12 +41,6 @@ export const TrialManagementTable = ({
     trialUser: TrialManagementTableFragment,
   ) => {
     await enableTrialUserMutation({
-      refetchQueries: [
-        {
-          query: TrialManagementPageDocument,
-          variables: { userId: user?.uid },
-        },
-      ],
       variables: { userId: trialUser.id },
     })
   }


### PR DESCRIPTION
参考

[Apollo Clientのキャッシュの仕組みとローカルの状態管理について](https://zenn.dev/kazu777/articles/b64935ea7d6fee)